### PR TITLE
change order of channels in conda environment

### DIFF
--- a/content/Software/install_python.md
+++ b/content/Software/install_python.md
@@ -161,8 +161,8 @@ on your local hard drive:
     :::yaml
     name: geo_scipy
     channels:
-        - defaults
         - conda-forge
+        - defaults
     dependencies:
         - python=3.6    # Python version 3.6
         - bottleneck    # C-optimized array functions for NumPy


### PR DESCRIPTION
I had to switch this to put conda-forge first.

Otherwise I got a library error when trying to import netCDF4 in os-x.

cc @darothen ... you will have the same issue in your gcpy environment